### PR TITLE
Fix: get adapter should not panic when not nil

### DIFF
--- a/graph_service_client.go
+++ b/graph_service_client.go
@@ -53,7 +53,7 @@ func NewGraphServiceClientWithCredentialsAndHosts(credential azcore.TokenCredent
 
 // GetAdapter returns the client current adapter, Method should only be called when the user is certain an adapter has been provided
 func (m *GraphBaseServiceClient) GetAdapter() abstractions.RequestAdapter {
-	if m.requestAdapter != nil {
+	if m.requestAdapter == nil {
 		panic(errors.New("request adapter has not been initialized"))
 	}
 	return m.requestAdapter

--- a/test/graph_service_client_test.go
+++ b/test/graph_service_client_test.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	msgraphbetasdkgo "github.com/microsoftgraph/msgraph-beta-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func NewSimpleCredentials(token string) *SimpleCredentials {
+	return &SimpleCredentials{
+		TokenValue: token,
+	}
+}
+
+type SimpleCredentials struct {
+	TokenValue string
+}
+
+func (m *SimpleCredentials) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token: m.TokenValue,
+	}, nil
+}
+
+func TestNewGraphServiceClientWithCredentialsInitializesAClient(t *testing.T) {
+	cred := NewSimpleCredentials("asdasd")
+	client, _ := msgraphbetasdkgo.NewGraphServiceClientWithCredentials(cred, []string{"Files.Read"})
+
+	assert.NotNil(t, client)
+}
+
+func TestNewGraphServiceClientWithCredentialsAndHostsInitializesAClient(t *testing.T) {
+	cred := NewSimpleCredentials("asdasd")
+	client, _ := msgraphbetasdkgo.NewGraphServiceClientWithCredentialsAndHosts(cred, []string{"Files.Read"}, []string{"host1", "host2"})
+
+	assert.NotNil(t, client)
+}
+
+func TestClientAccessToGeneratedMethods(t *testing.T) {
+	cred := NewSimpleCredentials("asdasd")
+	client, _ := msgraphbetasdkgo.NewGraphServiceClientWithCredentials(cred, []string{"Files.Read"})
+
+	assert.NotNil(t, client.Groups())
+}
+
+func TestGetAdapterMethodThrowErrorOnNill(t *testing.T) {
+	cred := NewSimpleCredentials("asdasd")
+	client, _ := msgraphbetasdkgo.NewGraphServiceClientWithCredentials(cred, []string{"Files.Read"})
+	assert.NotNil(t, client.GetAdapter())
+}


### PR DESCRIPTION
Fix: Get adapter should not panic when not nil