### PR TITLE
Recall release versions 0.105.0 and 0.105.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,10 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v0.105.0
+	// release contains a unintentined breaking change in name of classes
+	v0.105.1
+	// release contains a unintentined breaking change in name of classes
+)


### PR DESCRIPTION
## Overview

Recall versions 0.105.0 and 0.105.1
Blocked by https://github.com/microsoft/kiota/pull/4817
